### PR TITLE
refactor: computed student lifecycle (pending/active/suspended)

### DIFF
--- a/app/Enums/StudentStatus.php
+++ b/app/Enums/StudentStatus.php
@@ -4,7 +4,7 @@ namespace App\Enums;
 
 enum StudentStatus: string
 {
+    case Pending = 'pending';
     case Active = 'active';
-    case Inactive = 'inactive';
     case Suspended = 'suspended';
 }

--- a/app/Http/Controllers/Tenant/StudentController.php
+++ b/app/Http/Controllers/Tenant/StudentController.php
@@ -16,14 +16,6 @@ use Inertia\Inertia;
 
 class StudentController extends Controller
 {
-    private function statusOptions(): array
-    {
-        return array_map(
-            fn (StudentStatus $s) => ['value' => $s->value, 'label' => $s->name],
-            StudentStatus::cases()
-        );
-    }
-
     public function index(Request $request)
     {
         $this->authorize('viewAny', Student::class);
@@ -39,13 +31,26 @@ class StudentController extends Controller
         }
 
         $status = $request->input('status', 'active');
+
         if ($status && $status !== 'all') {
-            $query->where('status', $status);
+            if ($status === 'suspended') {
+                $query->where('status', 'suspended');
+            } elseif ($status === 'active') {
+                $query->whereNull('status')
+                    ->whereHas('enrollmentFees', function ($q) {
+                        $q->where('expires_at', '>', now());
+                    });
+            } elseif ($status === 'pending') {
+                $query->whereNull('status')
+                    ->whereDoesntHave('enrollmentFees', function ($q) {
+                        $q->where('expires_at', '>', now());
+                    });
+            }
         }
 
         $sortField = $request->input('sort', 'last_name');
         $sortDirection = $request->input('direction', 'asc');
-        $allowedSorts = ['first_name', 'last_name', 'email', 'status', 'enrolled_at', 'created_at'];
+        $allowedSorts = ['first_name', 'last_name', 'email', 'enrolled_at', 'created_at'];
 
         if (in_array($sortField, $allowedSorts)) {
             $query->orderBy($sortField, $sortDirection === 'desc' ? 'desc' : 'asc');
@@ -78,7 +83,14 @@ class StudentController extends Controller
                 'direction' => $sortDirection,
                 'payments' => $request->boolean('payments'),
             ],
-            'statuses' => $this->statusOptions(),
+            'statuses' => array_map(
+                fn (StudentStatus $s) => ['value' => $s->value, 'label' => match ($s) {
+                    StudentStatus::Pending => 'In attesa',
+                    StudentStatus::Active => 'Attivo',
+                    StudentStatus::Suspended => 'Sospeso',
+                }],
+                StudentStatus::cases()
+            ),
             'paymentInfo' => $paymentInfo,
         ]);
     }
@@ -87,9 +99,7 @@ class StudentController extends Controller
     {
         $this->authorize('create', Student::class);
 
-        return Inertia::render('Tenant/Student/Create', [
-            'statuses' => $this->statusOptions(),
-        ]);
+        return Inertia::render('Tenant/Student/Create');
     }
 
     public function store(StoreStudentRequest $request)
@@ -152,7 +162,6 @@ class StudentController extends Controller
 
         return Inertia::render('Tenant/Student/Edit', [
             'student' => $student,
-            'statuses' => $this->statusOptions(),
         ]);
     }
 
@@ -190,6 +199,8 @@ class StudentController extends Controller
     {
         $this->authorize('update', $student);
 
+        $updates = ['status' => StudentStatus::Suspended];
+
         if ($student->current_cycle_started_at) {
             $pastCycles = $student->past_cycles ?? [];
             $pastCycles[] = [
@@ -197,34 +208,21 @@ class StudentController extends Controller
                 'ended_at' => now()->toDateString(),
                 'reason' => 'suspended',
             ];
-            $student->update([
-                'status' => StudentStatus::Suspended,
-                'current_cycle_started_at' => null,
-                'past_cycles' => $pastCycles,
-            ]);
-        } else {
-            $student->update(['status' => StudentStatus::Suspended]);
+            $updates['current_cycle_started_at'] = null;
+            $updates['past_cycles'] = $pastCycles;
         }
+
+        $student->update($updates);
 
         return redirect()->route('tenant.students.show', [tenant('slug'), $student])
             ->with('success', 'Allievo sospeso.');
-    }
-
-    public function archive(Student $student)
-    {
-        $this->authorize('update', $student);
-
-        $student->update(['status' => StudentStatus::Inactive]);
-
-        return redirect()->route('tenant.students.index', tenant('slug'))
-            ->with('success', 'Allievo archiviato.');
     }
 
     public function reactivate(Student $student)
     {
         $this->authorize('update', $student);
 
-        $student->update(['status' => StudentStatus::Active]);
+        $student->update(['status' => null]);
 
         return redirect()->route('tenant.students.show', [tenant('slug'), $student])
             ->with('success', 'Allievo riattivato.');
@@ -234,7 +232,10 @@ class StudentController extends Controller
     {
         $this->authorize('viewAny', Student::class);
 
-        $query = Student::where('status', 'active')
+        $query = Student::whereNull('status')
+            ->whereHas('enrollmentFees', function ($q) {
+                $q->where('expires_at', '>', now());
+            })
             ->select('id', 'first_name', 'last_name');
 
         if ($search = $request->input('q')) {

--- a/app/Http/Requests/Tenant/StoreStudentRequest.php
+++ b/app/Http/Requests/Tenant/StoreStudentRequest.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Requests\Tenant;
 
-use App\Enums\StudentStatus;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -31,7 +30,6 @@ class StoreStudentRequest extends FormRequest
             'emergency_contacts.*.phone' => ['required', 'string', 'max:50'],
             'phone_contact_index' => ['nullable', 'integer'],
             'notes' => ['nullable', 'string', 'max:5000'],
-            'status' => ['sometimes', Rule::enum(StudentStatus::class)],
             'enrolled_at' => ['nullable', 'date'],
             'monthly_fee_override' => ['nullable', 'numeric', 'min:0'],
         ];

--- a/app/Http/Requests/Tenant/UpdateStudentRequest.php
+++ b/app/Http/Requests/Tenant/UpdateStudentRequest.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Requests\Tenant;
 
-use App\Enums\StudentStatus;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -33,7 +32,6 @@ class UpdateStudentRequest extends FormRequest
             'emergency_contacts.*.phone' => ['required', 'string', 'max:50'],
             'phone_contact_index' => ['nullable', 'integer'],
             'notes' => ['nullable', 'string', 'max:5000'],
-            'status' => ['sometimes', Rule::enum(StudentStatus::class)],
             'enrolled_at' => ['nullable', 'date'],
             'monthly_fee_override' => ['nullable', 'numeric', 'min:0'],
         ];

--- a/app/Models/EnrollmentFee.php
+++ b/app/Models/EnrollmentFee.php
@@ -3,13 +3,14 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Stancl\Tenancy\Database\Concerns\BelongsToTenant;
 
 class EnrollmentFee extends Model
 {
-    use HasUuids, BelongsToTenant;
+    use HasUuids, HasFactory, BelongsToTenant;
 
     protected $fillable = ['student_id', 'payment_id', 'expected_amount', 'starts_at', 'expires_at', 'notes'];
 

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\StudentStatus;
+use App\Services\EnrollmentFeeService;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -11,7 +12,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use App\Services\EnrollmentFeeService;
 use Stancl\Tenancy\Database\Concerns\BelongsToTenant;
 
 class Student extends Model
@@ -22,13 +22,14 @@ class Student extends Model
         'first_name', 'last_name', 'email', 'phone',
         'date_of_birth', 'fiscal_code', 'address',
         'phone_contact_id',
-        'notes', 'enrolled_at',
+        'notes', 'status', 'enrolled_at',
         'monthly_fee_override', 'current_cycle_started_at', 'past_cycles',
     ];
 
     protected $casts = [
         'date_of_birth' => 'date:Y-m-d',
         'enrolled_at' => 'date:Y-m-d',
+        'status' => StudentStatus::class,
         'current_cycle_started_at' => 'date:Y-m-d',
         'monthly_fee_override' => 'integer',
         'past_cycles' => 'array',
@@ -54,7 +55,7 @@ class Student extends Model
     protected function effectiveStatus(): Attribute
     {
         return Attribute::get(function (): string {
-            if ($this->status === 'suspended') {
+            if ($this->status === StudentStatus::Suspended) {
                 return StudentStatus::Suspended->value;
             }
 

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Services\EnrollmentFeeService;
 use Stancl\Tenancy\Database\Concerns\BelongsToTenant;
 
 class Student extends Model
@@ -21,20 +22,19 @@ class Student extends Model
         'first_name', 'last_name', 'email', 'phone',
         'date_of_birth', 'fiscal_code', 'address',
         'phone_contact_id',
-        'notes', 'status', 'enrolled_at',
+        'notes', 'enrolled_at',
         'monthly_fee_override', 'current_cycle_started_at', 'past_cycles',
     ];
 
     protected $casts = [
         'date_of_birth' => 'date:Y-m-d',
         'enrolled_at' => 'date:Y-m-d',
-        'status' => StudentStatus::class,
         'current_cycle_started_at' => 'date:Y-m-d',
         'monthly_fee_override' => 'integer',
         'past_cycles' => 'array',
     ];
 
-    protected $appends = ['effective_phone'];
+    protected $appends = ['effective_phone', 'effective_status'];
 
     protected function effectivePhone(): Attribute
     {
@@ -48,6 +48,22 @@ class Student extends Model
             }
 
             return $this->phone;
+        });
+    }
+
+    protected function effectiveStatus(): Attribute
+    {
+        return Attribute::get(function (): string {
+            if ($this->status === 'suspended') {
+                return StudentStatus::Suspended->value;
+            }
+
+            $enrollmentService = app(EnrollmentFeeService::class);
+            if ($enrollmentService->hasValidEnrollment($this)) {
+                return StudentStatus::Active->value;
+            }
+
+            return StudentStatus::Pending->value;
         });
     }
 

--- a/app/Services/EnrollmentFeeService.php
+++ b/app/Services/EnrollmentFeeService.php
@@ -71,6 +71,20 @@ class EnrollmentFeeService
     }
 
     /**
+     * Check if a student has a currently valid enrollment.
+     */
+    public function hasValidEnrollment(Student $student): bool
+    {
+        $latest = $this->getLatestEnrollment($student);
+
+        if ($latest === null) {
+            return false;
+        }
+
+        return $latest->expires_at->isFuture();
+    }
+
+    /**
      * Get the latest enrollment fee for a student.
      */
     public function getLatestEnrollment(Student $student): ?EnrollmentFee

--- a/database/factories/EnrollmentFeeFactory.php
+++ b/database/factories/EnrollmentFeeFactory.php
@@ -17,7 +17,7 @@ class EnrollmentFeeFactory extends Factory
         return [
             'student_id' => Student::factory(),
             'payment_id' => Payment::factory(),
-            'expected_amount' => fake()->randomInt(3000, 8000),
+            'expected_amount' => fake()->numberBetween(3000, 8000),
             'starts_at' => now(),
             'expires_at' => now()->addYear(),
             'notes' => null,

--- a/database/factories/EnrollmentFeeFactory.php
+++ b/database/factories/EnrollmentFeeFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\EnrollmentFee;
+use App\Models\Payment;
+use App\Models\Student;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<EnrollmentFee> */
+class EnrollmentFeeFactory extends Factory
+{
+    protected $model = EnrollmentFee::class;
+
+    public function definition(): array
+    {
+        return [
+            'student_id' => Student::factory(),
+            'payment_id' => Payment::factory(),
+            'expected_amount' => fake()->randomInt(3000, 8000),
+            'starts_at' => now(),
+            'expires_at' => now()->addYear(),
+            'notes' => null,
+        ];
+    }
+}

--- a/database/factories/StudentFactory.php
+++ b/database/factories/StudentFactory.php
@@ -2,7 +2,6 @@
 
 namespace Database\Factories;
 
-use App\Enums\StudentStatus;
 use App\Models\Student;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -22,7 +21,7 @@ class StudentFactory extends Factory
             'fiscal_code' => strtoupper(fake()->bothify('??????##?##?###?')),
             'address' => fake()->address(),
             'notes' => null,
-            'status' => StudentStatus::Active,
+            'status' => null,
             'enrolled_at' => now(),
             'monthly_fee_override' => null,
             'current_cycle_started_at' => null,
@@ -30,13 +29,8 @@ class StudentFactory extends Factory
         ];
     }
 
-    public function inactive(): static
-    {
-        return $this->state(['status' => StudentStatus::Inactive]);
-    }
-
     public function suspended(): static
     {
-        return $this->state(['status' => StudentStatus::Suspended]);
+        return $this->state(['status' => 'suspended']);
     }
 }

--- a/database/factories/StudentFactory.php
+++ b/database/factories/StudentFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\StudentStatus;
 use App\Models\Student;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -31,6 +32,6 @@ class StudentFactory extends Factory
 
     public function suspended(): static
     {
-        return $this->state(['status' => 'suspended']);
+        return $this->state(['status' => StudentStatus::Suspended]);
     }
 }

--- a/database/migrations/2026_04_09_000001_make_student_status_nullable.php
+++ b/database/migrations/2026_04_09_000001_make_student_status_nullable.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Step 1: Soft-delete all inactive students (they are archived)
+        // Must happen before making the column nullable, while NOT NULL is still enforced
+        DB::table('students')
+            ->whereNull('deleted_at')
+            ->where('status', 'inactive')
+            ->update(['deleted_at' => now()]);
+
+        // Step 2: Make the column nullable with default null
+        // Must happen before nulling out status values, as the column is currently NOT NULL
+        // Disable FK checks to avoid Doctrine DBAL triggering FK violation during column change
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        Schema::table('students', function (Blueprint $table) {
+            $table->string('status')->nullable()->default(null)->change();
+        });
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+        // Step 3: Null out all remaining non-suspended statuses (active → null)
+        // Disable FK checks in case dev DB has orphaned tenant rows from old test data
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        DB::table('students')
+            ->whereNull('deleted_at')
+            ->where('status', '!=', 'suspended')
+            ->update(['status' => null]);
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+
+    public function down(): void
+    {
+        // Step 1: Restore null status to 'active'
+        DB::table('students')
+            ->whereNull('status')
+            ->update(['status' => 'active']);
+
+        // Step 2: Restore column to non-nullable with default 'active'
+        Schema::table('students', function (Blueprint $table) {
+            $table->string('status')->nullable(false)->default('active')->change();
+        });
+    }
+};

--- a/database/migrations/2026_04_09_000001_make_student_status_nullable.php
+++ b/database/migrations/2026_04_09_000001_make_student_status_nullable.php
@@ -17,22 +17,15 @@ return new class extends Migration
             ->update(['deleted_at' => now()]);
 
         // Step 2: Make the column nullable with default null
-        // Must happen before nulling out status values, as the column is currently NOT NULL
-        // Disable FK checks to avoid Doctrine DBAL triggering FK violation during column change
-        DB::statement('SET FOREIGN_KEY_CHECKS=0');
         Schema::table('students', function (Blueprint $table) {
             $table->string('status')->nullable()->default(null)->change();
         });
-        DB::statement('SET FOREIGN_KEY_CHECKS=1');
 
         // Step 3: Null out all remaining non-suspended statuses (active → null)
-        // Disable FK checks in case dev DB has orphaned tenant rows from old test data
-        DB::statement('SET FOREIGN_KEY_CHECKS=0');
         DB::table('students')
             ->whereNull('deleted_at')
             ->where('status', '!=', 'suspended')
             ->update(['status' => null]);
-        DB::statement('SET FOREIGN_KEY_CHECKS=1');
     }
 
     public function down(): void

--- a/resources/js/components/student-form.tsx
+++ b/resources/js/components/student-form.tsx
@@ -9,9 +9,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
-import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import type { Student, StudentStatus } from '@/types';
+import type { Student } from '@/types';
 import { useTenant } from '@/hooks/use-tenant';
 import { useForm } from '@inertiajs/react';
 import { Phone, Plus, Trash2, Users } from 'lucide-react';
@@ -33,14 +32,12 @@ type StudentFormData = {
     emergency_contacts: EmergencyContactFormData[];
     phone_contact_index: number | null;
     notes: string;
-    status: string;
     enrolled_at: string;
     monthly_fee_override: string;
 };
 
 type Props = {
     student?: Student;
-    statuses: StudentStatus[];
     submitLabel: string;
     formId?: string;
 };
@@ -51,7 +48,7 @@ function initPhoneContactIndex(student?: Student): number | null {
     return idx >= 0 ? idx : null;
 }
 
-export function StudentForm({ student, statuses, submitLabel, formId }: Props) {
+export function StudentForm({ student, submitLabel, formId }: Props) {
     const tenant = useTenant();
 
     const { data, setData, post, put, processing, errors, transform } = useForm<StudentFormData>({
@@ -65,7 +62,6 @@ export function StudentForm({ student, statuses, submitLabel, formId }: Props) {
         emergency_contacts: student?.emergency_contacts?.map(c => ({ name: c.name, phone: c.phone })) ?? [],
         phone_contact_index: initPhoneContactIndex(student),
         notes: student?.notes ?? '',
-        status: student?.status ?? 'active',
         enrolled_at: student?.enrolled_at ?? new Date().toISOString().split('T')[0],
         monthly_fee_override: student?.monthly_fee_override !== null && student?.monthly_fee_override !== undefined
             ? (student.monthly_fee_override / 100).toFixed(2)
@@ -327,25 +323,6 @@ export function StudentForm({ student, statuses, submitLabel, formId }: Props) {
                     <CardTitle>Iscrizione</CardTitle>
                 </CardHeader>
                 <CardContent className="grid gap-4 sm:grid-cols-2">
-                    <Field data-invalid={!!errors.status}>
-                        <FieldLabel htmlFor="status">Stato</FieldLabel>
-                        <Select value={data.status} onValueChange={(value) => setData('status', value)}>
-                            <SelectTrigger aria-invalid={!!errors.status}>
-                                <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectGroup>
-                                    {statuses.map((s) => (
-                                        <SelectItem key={s.value} value={s.value}>
-                                            {s.label}
-                                        </SelectItem>
-                                    ))}
-                                </SelectGroup>
-                            </SelectContent>
-                        </Select>
-                        {errors.status && <FieldError>{errors.status}</FieldError>}
-                    </Field>
-
                     <Field data-invalid={!!errors.enrolled_at}>
                         <FieldLabel htmlFor="enrolled_at">Data iscrizione</FieldLabel>
                         <DatePicker

--- a/resources/js/lib/student-status.ts
+++ b/resources/js/lib/student-status.ts
@@ -1,11 +1,11 @@
-export const statusVariant: Record<string, 'default' | 'secondary' | 'destructive'> = {
+export const statusVariant: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+    pending: 'outline',
     active: 'default',
-    inactive: 'secondary',
     suspended: 'destructive',
 };
 
 export const statusLabel: Record<string, string> = {
+    pending: 'In attesa',
     active: 'Attivo',
-    inactive: 'Inattivo',
     suspended: 'Sospeso',
 };

--- a/resources/js/pages/Tenant/Student/Create.tsx
+++ b/resources/js/pages/Tenant/Student/Create.tsx
@@ -1,20 +1,15 @@
 import { StudentForm } from '@/components/student-form';
 import TenantLayout from '@/layouts/tenant-layout';
-import type { StudentStatus } from '@/types';
 import { Head } from '@inertiajs/react';
 import type { ReactNode } from 'react';
 
-type Props = {
-    statuses: StudentStatus[];
-};
-
-export default function StudentsCreate({ statuses }: Props) {
+export default function StudentsCreate() {
     return (
         <>
             <Head title="Nuovo allievo" />
             <div className="mx-auto w-full max-w-2xl p-4">
                 <h1 className="mb-6 text-2xl font-semibold">Nuovo allievo</h1>
-                <StudentForm statuses={statuses} submitLabel="Aggiungi allievo" />
+                <StudentForm submitLabel="Aggiungi allievo" />
             </div>
         </>
     );

--- a/resources/js/pages/Tenant/Student/Edit.tsx
+++ b/resources/js/pages/Tenant/Student/Edit.tsx
@@ -14,18 +14,17 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { StudentForm } from '@/components/student-form';
 import TenantLayout from '@/layouts/tenant-layout';
-import type { Student, StudentStatus } from '@/types';
+import type { Student } from '@/types';
 import { useTenant } from '@/hooks/use-tenant';
 import { Head, router } from '@inertiajs/react';
-import { Archive, Pause, Play } from 'lucide-react';
+import { Pause, Play, Trash2 } from 'lucide-react';
 import type { ReactElement } from 'react';
 
 type Props = {
     student: Student;
-    statuses: StudentStatus[];
 };
 
-export default function StudentsEdit({ student, statuses }: Props) {
+export default function StudentsEdit({ student }: Props) {
     const tenant = useTenant();
     const prefix = `/app/${tenant.slug}`;
 
@@ -44,121 +43,118 @@ export default function StudentsEdit({ student, statuses }: Props) {
                         </Button>
                     }
                 />
-                <StudentForm formId="student-form" student={student} statuses={statuses} submitLabel="Salva modifiche" />
+                <StudentForm formId="student-form" student={student} submitLabel="Salva modifiche" />
 
-                {student.status !== 'inactive' && (
-                    <Card className="mt-8 border-destructive">
-                        <CardHeader>
-                            <CardTitle className="text-destructive">Zona pericolosa</CardTitle>
-                        </CardHeader>
-                        <CardContent className="flex flex-col gap-4">
-                            {student.status === 'active' && (
-                                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                                    <div>
-                                        <p className="font-medium">Sospendi allievo</p>
-                                        <p className="text-sm text-muted-foreground">
-                                            L'allievo non potrà partecipare alle attività fino alla riattivazione.
-                                        </p>
-                                    </div>
-                                    <AlertDialog>
-                                        <AlertDialogTrigger asChild>
-                                            <Button variant="outline">
-                                                <Pause data-icon="inline-start" />
-                                                Sospendi
-                                            </Button>
-                                        </AlertDialogTrigger>
-                                        <AlertDialogContent>
-                                            <AlertDialogHeader>
-                                                <AlertDialogTitle>Sospendere questo allievo?</AlertDialogTitle>
-                                                <AlertDialogDescription>
-                                                    {student.first_name} {student.last_name} verrà sospeso.
-                                                    Potrai riattivarlo in qualsiasi momento.
-                                                </AlertDialogDescription>
-                                            </AlertDialogHeader>
-                                            <AlertDialogFooter>
-                                                <AlertDialogCancel>Annulla</AlertDialogCancel>
-                                                <AlertDialogAction
-                                                    onClick={() => router.put(`${prefix}/students/${student.id}/suspend`)}
-                                                >
-                                                    Sospendi
-                                                </AlertDialogAction>
-                                            </AlertDialogFooter>
-                                        </AlertDialogContent>
-                                    </AlertDialog>
-                                </div>
-                            )}
-
-                            {student.status === 'suspended' && (
-                                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                                    <div>
-                                        <p className="font-medium">Riattiva allievo</p>
-                                        <p className="text-sm text-muted-foreground">
-                                            L'allievo tornerà attivo e potrà partecipare alle attività.
-                                        </p>
-                                    </div>
-                                    <AlertDialog>
-                                        <AlertDialogTrigger asChild>
-                                            <Button variant="outline">
-                                                <Play data-icon="inline-start" />
-                                                Riattiva
-                                            </Button>
-                                        </AlertDialogTrigger>
-                                        <AlertDialogContent>
-                                            <AlertDialogHeader>
-                                                <AlertDialogTitle>Riattivare questo allievo?</AlertDialogTitle>
-                                                <AlertDialogDescription>
-                                                    {student.first_name} {student.last_name} tornerà attivo.
-                                                </AlertDialogDescription>
-                                            </AlertDialogHeader>
-                                            <AlertDialogFooter>
-                                                <AlertDialogCancel>Annulla</AlertDialogCancel>
-                                                <AlertDialogAction
-                                                    onClick={() => router.put(`${prefix}/students/${student.id}/reactivate`)}
-                                                >
-                                                    Riattiva
-                                                </AlertDialogAction>
-                                            </AlertDialogFooter>
-                                        </AlertDialogContent>
-                                    </AlertDialog>
-                                </div>
-                            )}
-
+                <Card className="mt-8 border-destructive">
+                    <CardHeader>
+                        <CardTitle className="text-destructive">Zona pericolosa</CardTitle>
+                    </CardHeader>
+                    <CardContent className="flex flex-col gap-4">
+                        {student.effective_status !== 'suspended' && (
                             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                                 <div>
-                                    <p className="font-medium">Archivia allievo</p>
+                                    <p className="font-medium">Sospendi allievo</p>
                                     <p className="text-sm text-muted-foreground">
-                                        L'allievo verrà archiviato e rimosso dalla lista attivi.
+                                        L'allievo non potrà partecipare alle attività fino alla riattivazione.
                                     </p>
                                 </div>
                                 <AlertDialog>
                                     <AlertDialogTrigger asChild>
-                                        <Button variant="destructive">
-                                            <Archive data-icon="inline-start" />
-                                            Archivia
+                                        <Button variant="outline">
+                                            <Pause data-icon="inline-start" />
+                                            Sospendi
                                         </Button>
                                     </AlertDialogTrigger>
                                     <AlertDialogContent>
                                         <AlertDialogHeader>
-                                            <AlertDialogTitle>Archiviare questo allievo?</AlertDialogTitle>
+                                            <AlertDialogTitle>Sospendere questo allievo?</AlertDialogTitle>
                                             <AlertDialogDescription>
-                                                {student.first_name} {student.last_name} verrà archiviato.
-                                                Potrai recuperarlo in futuro se necessario.
+                                                {student.first_name} {student.last_name} verrà sospeso.
+                                                Potrai riattivarlo in qualsiasi momento.
                                             </AlertDialogDescription>
                                         </AlertDialogHeader>
                                         <AlertDialogFooter>
                                             <AlertDialogCancel>Annulla</AlertDialogCancel>
                                             <AlertDialogAction
-                                                onClick={() => router.put(`${prefix}/students/${student.id}/archive`)}
+                                                onClick={() => router.put(`${prefix}/students/${student.id}/suspend`)}
                                             >
-                                                Archivia
+                                                Sospendi
                                             </AlertDialogAction>
                                         </AlertDialogFooter>
                                     </AlertDialogContent>
                                 </AlertDialog>
                             </div>
-                        </CardContent>
-                    </Card>
-                )}
+                        )}
+
+                        {student.effective_status === 'suspended' && (
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                <div>
+                                    <p className="font-medium">Riattiva allievo</p>
+                                    <p className="text-sm text-muted-foreground">
+                                        L'allievo tornerà al suo stato normale (in attesa o attivo in base all'iscrizione).
+                                    </p>
+                                </div>
+                                <AlertDialog>
+                                    <AlertDialogTrigger asChild>
+                                        <Button variant="outline">
+                                            <Play data-icon="inline-start" />
+                                            Riattiva
+                                        </Button>
+                                    </AlertDialogTrigger>
+                                    <AlertDialogContent>
+                                        <AlertDialogHeader>
+                                            <AlertDialogTitle>Riattivare questo allievo?</AlertDialogTitle>
+                                            <AlertDialogDescription>
+                                                {student.first_name} {student.last_name} verrà riattivato.
+                                            </AlertDialogDescription>
+                                        </AlertDialogHeader>
+                                        <AlertDialogFooter>
+                                            <AlertDialogCancel>Annulla</AlertDialogCancel>
+                                            <AlertDialogAction
+                                                onClick={() => router.put(`${prefix}/students/${student.id}/reactivate`)}
+                                            >
+                                                Riattiva
+                                            </AlertDialogAction>
+                                        </AlertDialogFooter>
+                                    </AlertDialogContent>
+                                </AlertDialog>
+                            </div>
+                        )}
+
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                                <p className="font-medium">Elimina allievo</p>
+                                <p className="text-sm text-muted-foreground">
+                                    L'allievo verrà rimosso dalla lista. Potrai recuperarlo in futuro se necessario.
+                                </p>
+                            </div>
+                            <AlertDialog>
+                                <AlertDialogTrigger asChild>
+                                    <Button variant="destructive">
+                                        <Trash2 data-icon="inline-start" />
+                                        Elimina
+                                    </Button>
+                                </AlertDialogTrigger>
+                                <AlertDialogContent>
+                                    <AlertDialogHeader>
+                                        <AlertDialogTitle>Eliminare questo allievo?</AlertDialogTitle>
+                                        <AlertDialogDescription>
+                                            {student.first_name} {student.last_name} verrà rimosso dalla lista.
+                                        </AlertDialogDescription>
+                                    </AlertDialogHeader>
+                                    <AlertDialogFooter>
+                                        <AlertDialogCancel>Annulla</AlertDialogCancel>
+                                        <AlertDialogAction
+                                            onClick={() => router.delete(`${prefix}/students/${student.id}`)}
+                                        >
+                                            Elimina
+                                        </AlertDialogAction>
+                                    </AlertDialogFooter>
+                                </AlertDialogContent>
+                            </AlertDialog>
+                        </div>
+                    </CardContent>
+                </Card>
             </div>
         </>
     );

--- a/resources/js/pages/Tenant/Student/Index.tsx
+++ b/resources/js/pages/Tenant/Student/Index.tsx
@@ -134,10 +134,10 @@ export default function StudentsIndex({ students, filters, statuses, paymentInfo
     }
 
     function renderActionCell(student: Student) {
-        if (student.status !== 'active') {
+        if (student.effective_status !== 'active') {
             return (
-                <Badge variant={statusVariant[student.status]}>
-                    {statusLabel[student.status]}
+                <Badge variant={statusVariant[student.effective_status]}>
+                    {statusLabel[student.effective_status]}
                 </Badge>
             );
         }
@@ -235,7 +235,7 @@ export default function StudentsIndex({ students, filters, statuses, paymentInfo
                                         </TableCell>
                                         {showPayments && isActiveFilter && (
                                             <TableCell className="text-center">
-                                                {student.status === 'active'
+                                                {student.effective_status === 'active'
                                                     ? renderPaymentIndicator(student)
                                                     : null}
                                             </TableCell>

--- a/resources/js/pages/Tenant/Student/Show.tsx
+++ b/resources/js/pages/Tenant/Student/Show.tsx
@@ -91,9 +91,18 @@ export default function StudentsShow({ student, availableGroups, paymentData }: 
                                 <CardHeader>
                                     <div className="flex items-center justify-between">
                                         <CardTitle>Dati personali</CardTitle>
-                                        <Badge variant={statusVariant[student.status]}>
-                                            {statusLabel[student.status]}
-                                        </Badge>
+                                        <div className="flex items-center gap-2">
+                                            <Badge variant={statusVariant[student.effective_status]}>
+                                                {statusLabel[student.effective_status]}
+                                            </Badge>
+                                            {student.effective_status === 'pending' && (
+                                                <span className="text-xs text-muted-foreground">
+                                                    {paymentData.latestEnrollment
+                                                        ? 'Iscrizione scaduta'
+                                                        : 'Iscrizione non effettuata'}
+                                                </span>
+                                            )}
+                                        </div>
                                     </div>
                                 </CardHeader>
                                 <CardContent>

--- a/resources/js/types/student.ts
+++ b/resources/js/types/student.ts
@@ -24,7 +24,8 @@ export type Student = {
     }>;
     monthly_fee_override: number | null;
     notes: string | null;
-    status: 'active' | 'inactive' | 'suspended';
+    status: 'suspended' | null;
+    effective_status: 'pending' | 'active' | 'suspended';
     enrolled_at: string | null;
     created_at: string;
     updated_at: string;

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -22,8 +22,6 @@ Route::middleware(['web', 'auth', InitializeTenancyByPath::class, 'tenant.access
 
         Route::put('students/{student}/suspend', [StudentController::class, 'suspend'])
             ->name('tenant.students.suspend');
-        Route::put('students/{student}/archive', [StudentController::class, 'archive'])
-            ->name('tenant.students.archive');
         Route::put('students/{student}/reactivate', [StudentController::class, 'reactivate'])
             ->name('tenant.students.reactivate');
 

--- a/tests/Feature/Tenant/StudentControllerTest.php
+++ b/tests/Feature/Tenant/StudentControllerTest.php
@@ -2,6 +2,8 @@
 
 use App\Enums\StudentStatus;
 use App\Models\EmergencyContact;
+use App\Models\EnrollmentFee;
+use App\Models\Payment;
 use App\Models\Student;
 use App\Models\Tenant;
 use App\Models\User;
@@ -23,7 +25,7 @@ afterEach(function () {
 test('index mostra la lista allievi', function () {
     Student::factory()->count(3)->create();
 
-    $response = $this->get("/app/{$this->tenant->slug}/students");
+    $response = $this->get("/app/{$this->tenant->slug}/students?status=all");
 
     $response->assertOk();
     $response->assertInertia(fn ($page) => $page
@@ -33,8 +35,23 @@ test('index mostra la lista allievi', function () {
 });
 
 test('index filtra per stato', function () {
-    Student::factory()->count(2)->create(['status' => StudentStatus::Active]);
-    Student::factory()->inactive()->create();
+    // 2 students with valid enrollment → effective_status = active
+    $activeStudents = Student::factory()->count(2)->create();
+    foreach ($activeStudents as $student) {
+        $payment = Payment::factory()->create(['student_id' => $student->id]);
+        EnrollmentFee::factory()->create([
+            'student_id' => $student->id,
+            'payment_id' => $payment->id,
+            'starts_at' => now()->subMonth(),
+            'expires_at' => now()->addMonths(11),
+        ]);
+    }
+
+    // 1 student without enrollment → effective_status = pending
+    Student::factory()->create();
+
+    // 1 suspended student
+    Student::factory()->suspended()->create();
 
     $response = $this->get("/app/{$this->tenant->slug}/students?status=active");
 
@@ -48,7 +65,7 @@ test('index cerca per nome', function () {
     Student::factory()->create(['first_name' => 'Marco', 'last_name' => 'Rossi']);
     Student::factory()->create(['first_name' => 'Luca', 'last_name' => 'Bianchi']);
 
-    $response = $this->get("/app/{$this->tenant->slug}/students?search=Marco");
+    $response = $this->get("/app/{$this->tenant->slug}/students?search=Marco&status=all");
 
     $response->assertOk();
     $response->assertInertia(fn ($page) => $page
@@ -281,7 +298,6 @@ test('emergency contacts rispettano isolamento tenant', function () {
 
 test('suspend archivia il ciclo corrente in past_cycles', function () {
     $student = Student::factory()->create([
-        'status' => StudentStatus::Active,
         'current_cycle_started_at' => '2026-01-16',
     ]);
 
@@ -298,7 +314,6 @@ test('suspend archivia il ciclo corrente in past_cycles', function () {
 
 test('suspend senza ciclo attivo non aggiunge past_cycles', function () {
     $student = Student::factory()->create([
-        'status' => StudentStatus::Active,
         'current_cycle_started_at' => null,
     ]);
 
@@ -317,6 +332,7 @@ test('reactivate mantiene current_cycle_started_at null', function () {
     $this->put("/app/{$this->tenant->slug}/students/{$student->id}/reactivate");
 
     $student->refresh();
-    expect($student->status)->toBe(StudentStatus::Active);
+    expect($student->status)->toBeNull();
+    expect($student->effective_status)->toBe('pending');
     expect($student->current_cycle_started_at)->toBeNull();
 });

--- a/tests/Feature/Tenant/StudentLifecycleTest.php
+++ b/tests/Feature/Tenant/StudentLifecycleTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Models\EnrollmentFee;
+use App\Models\Payment;
+use App\Models\Student;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\EnrollmentFeeService;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->tenant = Tenant::factory()->create(['owner_id' => $this->user->id]);
+    $this->user->update(['current_tenant_id' => $this->tenant->id]);
+    $this->actingAs($this->user);
+    tenancy()->initialize($this->tenant);
+});
+
+afterEach(function () {
+    tenancy()->end();
+});
+
+test('hasValidEnrollment returns false when student has no enrollment', function () {
+    $student = Student::factory()->create();
+    $service = app(EnrollmentFeeService::class);
+
+    expect($service->hasValidEnrollment($student))->toBeFalse();
+});
+
+test('hasValidEnrollment returns true when student has active enrollment', function () {
+    $student = Student::factory()->create();
+    $payment = Payment::factory()->create(['student_id' => $student->id]);
+    EnrollmentFee::factory()->create([
+        'student_id' => $student->id,
+        'payment_id' => $payment->id,
+        'starts_at' => now()->subMonth(),
+        'expires_at' => now()->addMonths(11),
+    ]);
+    $service = app(EnrollmentFeeService::class);
+
+    expect($service->hasValidEnrollment($student))->toBeTrue();
+});
+
+test('hasValidEnrollment returns false when enrollment is expired', function () {
+    $student = Student::factory()->create();
+    $payment = Payment::factory()->create(['student_id' => $student->id]);
+    EnrollmentFee::factory()->create([
+        'student_id' => $student->id,
+        'payment_id' => $payment->id,
+        'starts_at' => now()->subYear()->subMonth(),
+        'expires_at' => now()->subMonth(),
+    ]);
+    $service = app(EnrollmentFeeService::class);
+
+    expect($service->hasValidEnrollment($student))->toBeFalse();
+});
+
+test('new student without enrollment has effective_status pending', function () {
+    $student = Student::factory()->create();
+
+    expect($student->effective_status)->toBe('pending');
+});
+
+test('student with valid enrollment has effective_status active', function () {
+    $student = Student::factory()->create();
+    $payment = Payment::factory()->create(['student_id' => $student->id]);
+    EnrollmentFee::factory()->create([
+        'student_id' => $student->id,
+        'payment_id' => $payment->id,
+        'starts_at' => now()->subMonth(),
+        'expires_at' => now()->addMonths(11),
+    ]);
+
+    $student->refresh();
+    expect($student->effective_status)->toBe('active');
+});
+
+test('student with expired enrollment has effective_status pending', function () {
+    $student = Student::factory()->create();
+    $payment = Payment::factory()->create(['student_id' => $student->id]);
+    EnrollmentFee::factory()->create([
+        'student_id' => $student->id,
+        'payment_id' => $payment->id,
+        'starts_at' => now()->subYear()->subMonth(),
+        'expires_at' => now()->subMonth(),
+    ]);
+
+    $student->refresh();
+    expect($student->effective_status)->toBe('pending');
+});
+
+test('suspended student has effective_status suspended regardless of enrollment', function () {
+    $student = Student::factory()->create();
+    $student->forceFill(['status' => 'suspended'])->save();
+    $payment = Payment::factory()->create(['student_id' => $student->id]);
+    EnrollmentFee::factory()->create([
+        'student_id' => $student->id,
+        'payment_id' => $payment->id,
+        'starts_at' => now()->subMonth(),
+        'expires_at' => now()->addMonths(11),
+    ]);
+
+    $student->refresh();
+    expect($student->effective_status)->toBe('suspended');
+});

--- a/tests/Feature/Tenant/StudentLifecycleTest.php
+++ b/tests/Feature/Tenant/StudentLifecycleTest.php
@@ -102,3 +102,83 @@ test('suspended student has effective_status suspended regardless of enrollment'
     $student->refresh();
     expect($student->effective_status)->toBe('suspended');
 });
+
+test('enrollment payment transitions student from pending to active', function () {
+    $student = Student::factory()->create();
+    expect($student->effective_status)->toBe('pending');
+
+    $service = app(EnrollmentFeeService::class);
+    $service->registerEnrollment($student, 5000);
+
+    $student->refresh();
+    expect($student->effective_status)->toBe('active');
+});
+
+test('suspended student stays suspended even after enrollment payment', function () {
+    $student = Student::factory()->create();
+    $student->update(['status' => 'suspended']);
+
+    $service = app(EnrollmentFeeService::class);
+    $service->registerEnrollment($student, 5000);
+
+    $student->refresh();
+    expect($student->effective_status)->toBe('suspended');
+});
+
+test('reactivating suspended student with valid enrollment shows active', function () {
+    $student = Student::factory()->create();
+    $student->update(['status' => 'suspended']);
+
+    $service = app(EnrollmentFeeService::class);
+    $service->registerEnrollment($student, 5000);
+
+    $this->put("/app/{$this->tenant->slug}/students/{$student->id}/reactivate");
+
+    $student->refresh();
+    expect($student->effective_status)->toBe('active');
+});
+
+test('reactivating suspended student without enrollment shows pending', function () {
+    $student = Student::factory()->create();
+    $student->update(['status' => 'suspended']);
+
+    $this->put("/app/{$this->tenant->slug}/students/{$student->id}/reactivate");
+
+    $student->refresh();
+    expect($student->effective_status)->toBe('pending');
+});
+
+test('soft-deleted student is not visible in index', function () {
+    $student = Student::factory()->create();
+    $student->delete();
+
+    $response = $this->get("/app/{$this->tenant->slug}/students?status=all");
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->has('students', 0)
+    );
+});
+
+test('tenant isolation: tenant A cannot see tenant B students', function () {
+    Student::factory()->create();
+
+    $otherUser = User::factory()->create();
+    $otherTenant = Tenant::factory()->create(['owner_id' => $otherUser->id]);
+
+    $response = $this->get("/app/{$otherTenant->slug}/students");
+
+    $response->assertForbidden();
+});
+
+test('store does not accept status field', function () {
+    $response = $this->post("/app/{$this->tenant->slug}/students", [
+        'first_name' => 'Marco',
+        'last_name' => 'Rossi',
+        'status' => 'active',
+    ]);
+
+    $response->assertRedirect();
+    $student = Student::where('first_name', 'Marco')->first();
+    expect($student->getRawOriginal('status'))->toBeNull();
+});

--- a/tests/Feature/Tenant/StudentLifecycleTest.php
+++ b/tests/Feature/Tenant/StudentLifecycleTest.php
@@ -90,7 +90,7 @@ test('student with expired enrollment has effective_status pending', function ()
 
 test('suspended student has effective_status suspended regardless of enrollment', function () {
     $student = Student::factory()->create();
-    $student->forceFill(['status' => 'suspended'])->save();
+    $student->update(['status' => 'suspended']);
     $payment = Payment::factory()->create(['student_id' => $student->id]);
     EnrollmentFee::factory()->create([
         'student_id' => $student->id,

--- a/tests/Feature/Tenant/StudentPaymentDataTest.php
+++ b/tests/Feature/Tenant/StudentPaymentDataTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Enums\StudentStatus;
+use App\Models\EnrollmentFee;
 use App\Models\Group;
+use App\Models\Payment;
 use App\Models\Student;
 use App\Models\Tenant;
 use App\Models\User;
@@ -97,7 +99,7 @@ test('index with payments=1 includes paymentInfo', function () {
     ]);
     $student->groups()->attach($group->id, ['is_primary' => true]);
 
-    $response = $this->get("/app/{$this->tenant->slug}/students?payments=1");
+    $response = $this->get("/app/{$this->tenant->slug}/students?status=all&payments=1");
 
     $response->assertOk();
     $response->assertInertia(fn ($page) => $page
@@ -131,8 +133,22 @@ test('index filters include payments flag', function () {
 // ─── index default status filter ────────────────────────────────────────────
 
 test('index defaults to status=active filter', function () {
-    Student::factory()->count(2)->create(['status' => StudentStatus::Active]);
-    Student::factory()->inactive()->create();
+    // 2 students with valid enrollment → effective_status = active
+    $activeStudents = Student::factory()->count(2)->create();
+    foreach ($activeStudents as $student) {
+        $payment = Payment::factory()->create(['student_id' => $student->id]);
+        EnrollmentFee::factory()->create([
+            'student_id' => $student->id,
+            'payment_id' => $payment->id,
+            'starts_at' => now()->subMonth(),
+            'expires_at' => now()->addMonths(11),
+        ]);
+    }
+
+    // 1 pending student (no enrollment)
+    Student::factory()->create();
+
+    // 1 suspended student
     Student::factory()->suspended()->create();
 
     $response = $this->get("/app/{$this->tenant->slug}/students");
@@ -145,8 +161,22 @@ test('index defaults to status=active filter', function () {
 });
 
 test('index with status=all shows all students', function () {
-    Student::factory()->count(2)->create(['status' => StudentStatus::Active]);
-    Student::factory()->inactive()->create();
+    // 2 students with valid enrollment
+    $activeStudents = Student::factory()->count(2)->create();
+    foreach ($activeStudents as $student) {
+        $payment = Payment::factory()->create(['student_id' => $student->id]);
+        EnrollmentFee::factory()->create([
+            'student_id' => $student->id,
+            'payment_id' => $payment->id,
+            'starts_at' => now()->subMonth(),
+            'expires_at' => now()->addMonths(11),
+        ]);
+    }
+
+    // 1 pending student (no enrollment)
+    Student::factory()->create();
+
+    // 1 suspended student
     Student::factory()->suspended()->create();
 
     $response = $this->get("/app/{$this->tenant->slug}/students?status=all");
@@ -161,7 +191,7 @@ test('index with status=all shows all students', function () {
 test('index paymentInfo has_rate is false when student has no groups', function () {
     $student = Student::factory()->create();
 
-    $response = $this->get("/app/{$this->tenant->slug}/students?payments=1");
+    $response = $this->get("/app/{$this->tenant->slug}/students?status=all&payments=1");
 
     $response->assertOk();
     $response->assertInertia(fn ($page) => $page

--- a/tests/Feature/Tenant/StudentSearchTest.php
+++ b/tests/Feature/Tenant/StudentSearchTest.php
@@ -1,10 +1,22 @@
 <?php
 
-use App\Enums\StudentStatus;
+use App\Models\EnrollmentFee;
 use App\Models\Group;
+use App\Models\Payment;
 use App\Models\Student;
 use App\Models\Tenant;
 use App\Models\User;
+
+function giveValidEnrollment(Student $student): void
+{
+    $payment = Payment::factory()->create(['student_id' => $student->id]);
+    EnrollmentFee::factory()->create([
+        'student_id' => $student->id,
+        'payment_id' => $payment->id,
+        'starts_at' => now()->subMonth(),
+        'expires_at' => now()->addMonths(11),
+    ]);
+}
 
 beforeEach(function () {
     $this->user = User::factory()->create();
@@ -21,8 +33,13 @@ afterEach(function () {
 });
 
 test('search restituisce solo studenti attivi', function () {
-    Student::factory()->create(['first_name' => 'Marco', 'status' => StudentStatus::Active]);
-    Student::factory()->inactive()->create(['first_name' => 'Luca']);
+    $active = Student::factory()->create(['first_name' => 'Marco']);
+    giveValidEnrollment($active);
+
+    // Pending student (no enrollment) — should NOT appear
+    Student::factory()->create(['first_name' => 'Luca']);
+
+    // Suspended student — should NOT appear
     Student::factory()->suspended()->create(['first_name' => 'Anna']);
 
     $response = $this->getJson("/app/{$this->tenant->slug}/students/search");
@@ -33,9 +50,14 @@ test('search restituisce solo studenti attivi', function () {
 });
 
 test('search filtra per nome', function () {
-    Student::factory()->create(['first_name' => 'Marco', 'last_name' => 'Rossi']);
-    Student::factory()->create(['first_name' => 'Luca', 'last_name' => 'Bianchi']);
-    Student::factory()->create(['first_name' => 'Anna', 'last_name' => 'Marchetti']);
+    $marco = Student::factory()->create(['first_name' => 'Marco', 'last_name' => 'Rossi']);
+    giveValidEnrollment($marco);
+
+    $luca = Student::factory()->create(['first_name' => 'Luca', 'last_name' => 'Bianchi']);
+    giveValidEnrollment($luca);
+
+    $anna = Student::factory()->create(['first_name' => 'Anna', 'last_name' => 'Marchetti']);
+    giveValidEnrollment($anna);
 
     $response = $this->getJson("/app/{$this->tenant->slug}/students/search?q=Marc");
 
@@ -46,8 +68,11 @@ test('search filtra per nome', function () {
 });
 
 test('search filtra per cognome', function () {
-    Student::factory()->create(['first_name' => 'Marco', 'last_name' => 'Rossi']);
-    Student::factory()->create(['first_name' => 'Luca', 'last_name' => 'Bianchi']);
+    $marco = Student::factory()->create(['first_name' => 'Marco', 'last_name' => 'Rossi']);
+    giveValidEnrollment($marco);
+
+    $luca = Student::factory()->create(['first_name' => 'Luca', 'last_name' => 'Bianchi']);
+    giveValidEnrollment($luca);
 
     $response = $this->getJson("/app/{$this->tenant->slug}/students/search?q=Rossi");
 
@@ -59,7 +84,10 @@ test('search filtra per cognome', function () {
 test('search con exclude_group esclude studenti già nel gruppo', function () {
     $group = Group::factory()->create();
     $studentInGroup = Student::factory()->create(['first_name' => 'Marco']);
+    giveValidEnrollment($studentInGroup);
+
     $studentNotInGroup = Student::factory()->create(['first_name' => 'Luca']);
+    giveValidEnrollment($studentNotInGroup);
 
     $group->students()->attach($studentInGroup->id);
 
@@ -72,7 +100,10 @@ test('search con exclude_group esclude studenti già nel gruppo', function () {
 });
 
 test('search limita a 10 risultati', function () {
-    Student::factory()->count(15)->create();
+    $students = Student::factory()->count(15)->create();
+    foreach ($students as $student) {
+        giveValidEnrollment($student);
+    }
 
     $response = $this->getJson("/app/{$this->tenant->slug}/students/search");
 
@@ -98,7 +129,10 @@ test('search richiede autenticazione', function () {
 });
 
 test('search senza query restituisce tutti gli studenti attivi', function () {
-    Student::factory()->count(3)->create(['status' => StudentStatus::Active]);
+    $students = Student::factory()->count(3)->create();
+    foreach ($students as $student) {
+        giveValidEnrollment($student);
+    }
 
     $response = $this->getJson("/app/{$this->tenant->slug}/students/search");
 
@@ -107,11 +141,12 @@ test('search senza query restituisce tutti gli studenti attivi', function () {
 });
 
 test('search restituisce solo id, first_name e last_name', function () {
-    Student::factory()->create([
+    $student = Student::factory()->create([
         'first_name' => 'Marco',
         'last_name' => 'Rossi',
         'email' => 'marco@example.com',
     ]);
+    giveValidEnrollment($student);
 
     $response = $this->getJson("/app/{$this->tenant->slug}/students/search");
 
@@ -122,9 +157,14 @@ test('search restituisce solo id, first_name e last_name', function () {
 });
 
 test('search ordina per cognome e nome', function () {
-    Student::factory()->create(['first_name' => 'Zara', 'last_name' => 'Bianchi']);
-    Student::factory()->create(['first_name' => 'Anna', 'last_name' => 'Bianchi']);
-    Student::factory()->create(['first_name' => 'Marco', 'last_name' => 'Rossi']);
+    $zara = Student::factory()->create(['first_name' => 'Zara', 'last_name' => 'Bianchi']);
+    giveValidEnrollment($zara);
+
+    $anna = Student::factory()->create(['first_name' => 'Anna', 'last_name' => 'Bianchi']);
+    giveValidEnrollment($anna);
+
+    $marco = Student::factory()->create(['first_name' => 'Marco', 'last_name' => 'Rossi']);
+    giveValidEnrollment($marco);
 
     $response = $this->getJson("/app/{$this->tenant->slug}/students/search");
 


### PR DESCRIPTION
## Summary

- **Status calcolato**: lo stato dello studente (`pending`, `active`, `suspended`) è ora derivato dai dati di iscrizione, non più scritto manualmente nel DB
- **DB semplificato**: la colonna `status` è nullable — salva solo `'suspended'` (manuale) o `null` (stato naturale calcolato dall'enrollment)
- **Archiviazione via soft delete**: rimossa la route `archive`, l'eliminazione (soft delete) copre questo caso

### Flusso lifecycle

```
Creato → pending (no enrollment valida)
  → Paga iscrizione → active
    → Iscrizione scade → pending ("Iscrizione scaduta")
  → Trainer sospende → suspended
    → Trainer riattiva → pending o active (in base a enrollment)
  → Elimina → soft delete
```

### Modifiche principali

- Migration: `status` nullable, migrazione dati esistenti
- `StudentStatus` enum: `Pending/Active/Suspended` (per label mapping)
- `Student::effectiveStatus` accessor: calcola lo stato da enrollment
- `EnrollmentFeeService::hasValidEnrollment()`: nuovo metodo
- Controller: filtri index per status effettivo, rimosso `archive()`
- Frontend: rimosso dropdown status dal form, badge usa `effective_status`, Show mostra contesto iscrizione
- 22 file modificati, 117 test passano (14 nuovi lifecycle tests)

## Test plan

- [x] 117 test passano (Pest)
- [x] Lifecycle: pending → active via enrollment payment
- [x] Lifecycle: suspended wins over enrollment
- [x] Lifecycle: reactivate restores computed status
- [x] Tenant isolation verificato
- [x] Store ignora campo status dall'input
- [x] Soft delete esclude da index
- [ ] Verificare UI in browser (badge, filtri, danger zone)
- [ ] Verificare su staging dopo merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)