### PR TITLE
chore: enable gorilla-docs plugin for the team

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "gorilla-docs@gorillaradio-dev-claude-plugins": true
+  }
+}


### PR DESCRIPTION
## Cosa

Versiona `.claude/settings.json` con l'abilitazione del plugin **gorilla-docs** dal marketplace `gorillaradio-dev-claude-plugins`.

## Perché

Condividere la skill `gorilla-docs` con il team: chi pulla `staging` se la ritrova attivata automaticamente (il marketplace è già registrato lato sviluppatori).

## Note

PR di sola configurazione tooling — nessun impatto su codice applicativo, build o runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)