### PR TITLE
ci: point staging deploy remote to gorillaradio-dev/hyoshi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
           script: |
             set -e
             cd /var/www/hyoshi-staging
-            git remote set-url origin git@github-hyoshi:gorillaradio/hyoshi.git
+            git remote set-url origin git@github-hyoshi:gorillaradio-dev/hyoshi.git
             rm -rf public/storage
             git pull origin staging
             composer install --no-dev --optimize-autoloader --no-interaction


### PR DESCRIPTION
## Cosa

Aggiorna `deploy.yml` per puntare il git remote del server di staging al nuovo path `gorillaradio-dev/hyoshi` (prima era `gorillaradio/hyoshi`).

## Perché

Il repo è stato trasferito dall'account personale `gorillaradio` all'org `gorillaradio-dev`. Il redirect GitHub copre comunque il vecchio path, ma è meglio essere espliciti.

## Effetto

Al primo deploy dopo il merge, lo step `git remote set-url` riscrive il remote sul server al path corretto — nessun intervento manuale richiesto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)