### PR TITLE
chore: declare marketplace source for auto-install

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,12 @@
 {
+  "extraKnownMarketplaces": {
+    "gorillaradio-dev-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "gorillaradio-dev/claude-plugins"
+      }
+    }
+  },
   "enabledPlugins": {
     "gorilla-docs@gorillaradio-dev-claude-plugins": true
   }


### PR DESCRIPTION
## Cosa

Aggiunge `extraKnownMarketplaces` in `.claude/settings.json`, puntando al repo del marketplace `gorillaradio-dev/claude-plugins`.

## Perché

Completa la condivisione iniziata con #8: ora chiunque cloni il repo — anche chi **non** ha ancora registrato il marketplace — viene proposto di installarlo automaticamente quando "fida" la cartella. Si abbina a `enabledPlugins` che attiva `gorilla-docs`.

## Note

È idempotente: per chi ha già il marketplace registrato, Claude Code usa la copia esistente invece di ri-clonare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)