### PR TITLE
chore: realign branch strategy — main becomes the active trunk

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,12 +2,12 @@ name: Deploy Hyoshi
 
 on:
   push:
-    branches: [staging]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
   deploy-staging:
-    if: github.ref_name == 'staging'
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
 
     steps:
@@ -24,7 +24,7 @@ jobs:
             cd /var/www/hyoshi-staging
             git remote set-url origin git@github-hyoshi:gorillaradio-dev/hyoshi.git
             rm -rf public/storage
-            git pull origin staging
+            git pull origin main
             composer install --no-dev --optimize-autoloader --no-interaction
             php artisan migrate --force
             php artisan optimize:clear

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,16 +3,12 @@ name: linter
 on:
   push:
     branches:
-      - develop
       - main
-      - master
-      - workos
+      - production
   pull_request:
     branches:
-      - develop
       - main
-      - master
-      - workos
+      - production
 
 permissions:
   contents: write

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -11,12 +11,12 @@ name: Sync docs to central portal
 # Prerequisite: a repo secret DOCS_SYNC_TOKEN — a fine-grained PAT with
 # Contents:Write scoped ONLY to the central repo.
 #
-# NOTE: trigger su `staging` (non `main`) perché in questo repo staging è
-# il branch attivo dove confluisce il lavoro e gira il deploy.
+# Trigger su `main`: è il branch attivo dove confluisce il lavoro e da cui
+# parte il deploy all'ambiente di staging.
 
 on:
   push:
-    branches: [staging]
+    branches: [main]
     paths:
       - 'docs/html/**'
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,16 +3,12 @@ name: tests
 on:
   push:
     branches:
-      - develop
       - main
-      - master
-      - workos
+      - production
   pull_request:
     branches:
-      - develop
       - main
-      - master
-      - workos
+      - production
 
 jobs:
   ci:


### PR DESCRIPTION
## Contesto

Questo repo ha la stessa anomalia gestita di recente su `lumina-db-test`:

- `staging` era il branch attivo (dove confluiscono le PR e da cui parte il deploy al server `hyoshi-staging`)
- `main` esisteva ma era abbandonato (26 commit indietro, strict ancestor di staging)
- Conseguenza: le PR mergiate in `staging` non chiudono automaticamente le issue (`Closes #N` funziona solo sul default branch)

## Decisione

Allineamento al modello standard:
- **`main`** → branch attivo di sviluppo, deploya sull'ambiente `hyoshi-staging`
- **`production`** → branch dedicato al deploy di produzione (creato dopo il merge di questa PR; server non ancora esistente)
- **`staging`** → congelato come legacy. Issue di reminder per eliminarlo verrà aperta dopo il fast-forward.

## Modifiche

| File | Cambio |
|---|---|
| `.github/workflows/deploy.yml` | trigger `[staging]` → `[main]`, `ref_name == 'main'`, `git pull origin main`. Path server invariato (`/var/www/hyoshi-staging` = nome ambiente, non branch). |
| `.github/workflows/sync-docs.yml` | trigger `[staging]` → `[main]` + commento esplicativo aggiornato. |
| `.github/workflows/tests.yml` | `branches: [main, production]` — rimossi `develop`, `master`, `workos` (legacy starter kit, mai usati). |
| `.github/workflows/lint.yml` | Stesso pattern di `tests.yml`. |

## Sequenza post-merge

Questa PR è **l'ultimo merge previsto su `staging`**. Dopo il merge:

```bash
# Fast-forward main ← staging (è strict ancestor → ff pulito)
git push origin origin/staging:main
# Crea production da main (vuoto concettualmente)
git push origin main:production
```

Il primo push su `main` triggererà il `deploy.yml` modificato → deploy a `hyoshi-staging` server come al solito.

## Punti di attenzione

- **Nessun rischio prod**: server `/var/www/hyoshi-production/` non esiste, `deploy-production` job non aggiunto qui (Rule 3, surgical changes — si aggiungerà quando ci sarà un server da deployare).
- **Worktree/cloni locali**: dopo il fast-forward, fare `git fetch && git checkout main && git pull` su ogni clone che oggi traccia `staging`.
- **Buco CI preesistente**: `tests.yml` e `lint.yml` finora non includevano `staging` → le PR storiche mergiate non hanno mai fatto girare la suite. Questa PR risolve anche quello (su `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)